### PR TITLE
fixed-bug-#7

### DIFF
--- a/src/js/menu-bar.js
+++ b/src/js/menu-bar.js
@@ -79,20 +79,20 @@ var template = [{
         {
             label: "剪切(&T)",
             accelerator: 'CmdOrCtrl+X',
-            click: cut,
-            selector: 'cut:'
+            selector: 'cut:',
+            role: 'cut'
         },
         {
             label: "复制(&C)",
             accelerator: 'CmdOrCtrl+C',
-            click: copy,
-            selector: 'copy:'
+            selector: 'copy:',
+            role: 'copy'
         },
         {
             label: "粘贴(&P)",
             accelerator: 'CmdOrCtrl+V',
-            click: paste,
-            selector: 'paste:'
+            selector: 'paste:',
+            role: 'paste'
         }
     ]
 }, {


### PR DESCRIPTION
修复 MAC版复制和粘贴快捷键无法使用
https://github.com/NaoTu/DesktopNaotu/issues/7#issuecomment-427710210

只需要改动 `剪贴`， `复制` , `粘贴` 即可